### PR TITLE
Added command-line arguments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -124,6 +124,16 @@ for a beginner's guide, which will explain far better than this section will be 
     the VERY FIRST line, and it will read the ENTIRE line. Once you've written out the path, leave it
     alone.
 
+    ## 2.1.1: (Optional) Setting Your Steam Directory
+
+    Globin is able to launch World of Goo with "run" command line argument. However, the Steam version 
+    of World Of Goo will not start if you try to launch the executable directly. If you have the Steam
+    version of the game and want to launch World of Goo after building the addins, provide the directory
+    of Steam in "steam_directory.txt".
+
+    The rules for specifying the Steam directory are the same as the rules for specifying World of Goo
+    directory.
+
     ## 2.2: Adding Addins
 
     As mentioned in section 1, Globin operates using the organization system of .goomod files. However,
@@ -177,7 +187,13 @@ for a beginner's guide, which will explain far better than this section will be 
     Globin from the command line, navigate to the Globin directory and enter the command
     "python3 globin.py". This will automatically run Globin, installing all addins in the "addins"
     folder and placing a button in Chapter 1 for each installed level (except levels in full
-    chapters). If running Globin gives an error, refer to section 5.
+    chapters). After that, Globin automatically launches World of Goo. If running Globin gives 
+    an error, refer to section 5.
+
+    Globin supports several command-line arguments:
+    - "python3 globin.py run" is the default behavior, described above; 
+    - "python3 globin.py build" installs all addins without launching World Of Goo;
+    - "python3 globin.py help" displays the info message.
 
     Repeatedly using Globin will cause files with text appended to them (generally files in one or
     more "merge" folders) to build up with lots of text referencing the same object or objects.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@ Latest version: v0.9.1
 
 Version history:
 
+v0.9.2
+- Added command line arguments to Globin.
+
 v0.9.1
 - Globin no longer throws unnecessary errors when run from the Windows command console.
 

--- a/globin.py
+++ b/globin.py
@@ -2,15 +2,17 @@ from bs4 import BeautifulSoup
 from lxml import etree
 from math import floor
 import os
+import platform
 import shutil
 import sys
+import subprocess
 
 def main() :
     user_action         = ""
-    user_action_choices = ["build", "help"]
+    user_action_choices = ["build", "run", "help"]
 
     if len(sys.argv) <= 1:
-        user_action = "build"
+        user_action = "run"
     else:
         user_action = sys.argv[1]
 
@@ -18,24 +20,24 @@ def main() :
     if user_action not in user_action_choices:
         user_action = "help"
 
-    if user_action == "build":
+    if user_action == "build" or user_action == "run":
         print("Checking wog_directory.txt...\n")
-        read_directory = open("wog_directory.txt", "r")
-        wog_dir = read_directory.readline().strip()
-        read_directory.close()
+        wog_dir = read_directory_from_file("wog_directory.txt")
         print(f"World of Goo directory set to {wog_dir}.")
 
-        build_addins(wog_dir)
+        if build_addins(wog_dir) and user_action == "run":
+            launch_world_of_goo(wog_dir)
 
     if user_action == "help":
         display_help()
-    
+
 def display_help():
     print("--- Globin ver. 0.9 ---")
     print("A tool for installing mods for World of Goo 1.5\n")
 
     print("Usage:")
     print("python globin.py build: Installs the addins to the World Of Goo directory")
+    print("python globin.py run:   Installs the addins and launches World Of Goo")
     print("python globin.py help:  Displays this message")
 
 def build_addins(wog_dir):
@@ -173,12 +175,81 @@ def build_addins(wog_dir):
         print("Cleaning up...")
         mergedir(os.getcwd(), "addin_cleanup", game_folder)
 
-        print("All addins installed. Thank you for using Globin.")
+        print("All addins installed. Thank you for using Globin.\n")
+
+        return True
     
     else :
         print("ERROR: Files were not verified successfully. You may be using an old version of World of Goo,")
         print("or a demo version. Globin will not work with these versions. If you are using the latest version,")
         print("make sure you've specified the directory correctly.\n\nGlobin will now exit.")
+
+        return False
+
+def launch_world_of_goo(wog_dir):
+    if platform.system() == "Windows":
+        launch_world_of_goo_windows(wog_dir)
+    
+    if platform.system() == "Linux":
+        launch_world_of_goo_linux(wog_dir)
+
+    if platform.system() == "Darwin":
+        launch_world_of_goo_macos(wog_dir)
+
+def launch_world_of_goo_windows(wog_dir):
+    is_steam_version = os.path.isfile(os.path.join(wog_dir, "steam_api.dll"))
+
+    if is_steam_version:
+        steam_path = read_directory_from_file("steam_directory.txt")
+        steam_executable = os.path.join(steam_path, "Steam.exe")
+
+        if os.path.isfile(steam_executable):
+            subprocess.Popen([steam_executable, "-applaunch", "22000"])
+
+        else:
+            print("LAUNCH ERROR. It seems you are using Steam version of the game,")
+            print("but the Steam directory you have specified is not correct.")
+            print("Please provide the correct directory in steam_directory.txt.")
+            
+    else:
+        #Apparently Epic Games version can also be launched directly from game .exe, starting the launcher if needed
+        game_executable = os.path.join(os.fspath(wog_dir), "WorldOfGoo.exe")
+        subprocess.Popen(game_executable)
+
+def launch_world_of_goo_linux(wog_dir):
+    is_steam_version = os.path.isfile(os.path.join(wog_dir, "lib/libsteam_api.so"))
+
+    if is_steam_version:
+        steam_command = "steam" #Steam on Linux can be launched with a single command
+        subprocess.Popen([steam_command, "-applaunch", "22000"])
+            
+    else:
+        game_executable = os.path.join(os.fspath(wog_dir), "WorldOfGoo.bin.x86_64")
+        subprocess.Popen(game_executable)
+
+def launch_world_of_goo_macos(wog_dir):
+    is_steam_version = os.path.isfile(os.path.join(wog_dir, "../Frameworks/libsteam_api.dylib"))
+
+    if is_steam_version:
+        steam_executable = "/Applications/Steam.app/Contents/MacOS/steam_osx" #Apparently apps on Mac are always installed in /Applications?
+
+        if os.path.isfile(steam_executable):
+            subprocess.Popen([steam_executable, "-applaunch", "22000"])
+
+        else:
+            print("LAUNCH ERROR. It seems you are using Steam version of the game,")
+            print("but there was a problem launching Steam.")
+            
+    else:
+        game_executable = os.path.join(os.fspath(wog_dir), "../MacOS/World of Goo")
+        subprocess.Popen(game_executable)
+
+def read_directory_from_file(filename):
+    read_directory = open(filename, "r")
+    directory = read_directory.readline().strip()
+    read_directory.close()
+
+    return directory
 
 def mergedir(home, target, game_folder) :
     content = os.path.join(home, target)

--- a/globin.py
+++ b/globin.py
@@ -3,17 +3,43 @@ from lxml import etree
 from math import floor
 import os
 import shutil
+import sys
 
 def main() :
+    user_action         = ""
+    user_action_choices = ["build", "help"]
+
+    if len(sys.argv) <= 1:
+        user_action = "build"
+    else:
+        user_action = sys.argv[1]
+
+    #Display the correct usage on unknown options
+    if user_action not in user_action_choices:
+        user_action = "help"
+
+    if user_action == "build":
+        print("Checking wog_directory.txt...\n")
+        read_directory = open("wog_directory.txt", "r")
+        wog_dir = read_directory.readline().strip()
+        read_directory.close()
+        print(f"World of Goo directory set to {wog_dir}.")
+
+        build_addins(wog_dir)
+
+    if user_action == "help":
+        display_help()
+    
+def display_help():
     print("--- Globin ver. 0.9 ---")
     print("A tool for installing mods for World of Goo 1.5\n")
 
+    print("Usage:")
+    print("python globin.py build: Installs the addins to the World Of Goo directory")
+    print("python globin.py help:  Displays this message")
+
+def build_addins(wog_dir):
     print("Starting...")
-    print("Checking wog_directory.txt...\n")
-    read_directory = open("wog_directory.txt", "r")
-    wog_dir = read_directory.readline().strip()
-    read_directory.close()
-    print(f"World of Goo directory set to {wog_dir}.")
     print("Verifying game files...")
     verifier = os.path.join(wog_dir, "game/res/levels/island3/pipecon_03@2x.png")
     if os.path.isfile(verifier) :


### PR DESCRIPTION
Added launch options to Globin, implemented as command-line arguments:
- "build" builds addins (old behavior);
- "run" launches World Of Goo after building addins;
- "help" displays an info message.

On Windows with the Steam version of the game, launching requires specifying Steam directory. This is done via new "steam_directory.txt" file. 