### PR TITLE
New "add" option to extract mods into "addins" folder

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,8 +20,11 @@
   -- 1.2: Extra Notes for GitHub
 - 2: Setting Up Globin
   -- 2.1: Setting Your World of Goo Directory
+     --- 2.1.1: (Optional) Setting Your Steam Directory
   -- 2.2: Adding Addins
-  -- 2.3: How To Unzip A .goomod File
+     --- 2.2.1: Unpacking .goomod Files Automatically
+     --- 2.2.2: Unpacking .goomod Files Manually
+  -- 2.3: Incompatible Addins
   -- 2.4: Dependencies
 - 3: Using Globin
   -- 3.1: Running Globin From Command Line
@@ -124,46 +127,41 @@ for a beginner's guide, which will explain far better than this section will be 
     the VERY FIRST line, and it will read the ENTIRE line. Once you've written out the path, leave it
     alone.
 
-    ## 2.1.1: (Optional) Setting Your Steam Directory
+        # 2.1.1: (Optional) Setting Your Steam Directory
 
-    Globin is able to launch World of Goo with "run" command line argument. However, the Steam version 
-    of World Of Goo will not start if you try to launch the executable directly. If you have the Steam
-    version of the game and want to launch World of Goo after building the addins, provide the directory
-    of Steam in "steam_directory.txt".
+        Globin is able to launch World of Goo with "run" command line argument. However, the Steam version 
+        of World Of Goo will not start if you try to launch the executable directly. If you have the Steam
+        version of the game and want to launch World of Goo after building the addins, provide the directory
+        of Steam in "steam_directory.txt".
 
-    The rules for specifying the Steam directory are the same as the rules for specifying World of Goo
-    directory.
+        The rules for specifying the Steam directory are the same as the rules for specifying World of Goo
+        directory.
 
     ## 2.2: Adding Addins
 
     As mentioned in section 1, Globin operates using the organization system of .goomod files. However,
     Globin is unable to read these files while they are compressed. To make them readable to Globin, 
     they need to be extracted to the "addins" folder. There are two ways to do it: automatic and manual.
-
-    As a brief footnote, not all addins you install will be compatible with each other, and sometimes
-    you may wish to remove some addins. In cases where you wish to table an incompatible addin or one
-    you just don't want anymore, you can move that addin to the "not-in-use" folder. This folder is not
-    read by Globin, it is simply there for ease of moving addins to and from the "addins" folder.
     
-    ## 2.2.1: Unpacking .goomod files automatically
+        # 2.2.1: Unpacking .goomod Files Automatically
     
-    To automatically extract the contents of a .goomod file into the Globin folder, run the Globin 
-    with "add" command line option. For example, to extract "C:\Users\Me\Documents\addin.goomod",
-    execute the following command:
-    - python3 globin.py add "C:\Users\Me\Documents\addin.goomod" 
+        To automatically extract the contents of a .goomod file into the Globin folder, run the Globin 
+        with "add" command line option. For example, to extract "C:\Users\Me\Documents\addin.goomod",
+        execute the following command:
+        - python3 globin.py add "C:\Users\Me\Documents\addin.goomod" 
 
-    ## 2.2.2: Unpacking .goomod Files Manually
+        # 2.2.2: Unpacking .goomod Files Manually
     
-    Extracting the contents of a .goomod file is required for Globin to read them. This is a fairly
-    simple step, but caution must be taken to not skip it. To extract the contents of a .goomod file,
-    first use the rename function to change the file's extension from .goomod to .zip. Some OSes will
-    warn you that this can make the file unstable; proceed anwyays. Once the file's extension is
-    changed, the .zip file can be opened as normal and extracted to the "addins" folder.
+        Extracting the contents of a .goomod file is required for Globin to read them. This is a fairly
+        simple step, but caution must be taken to not skip it. To extract the contents of a .goomod file,
+        first use the rename function to change the file's extension from .goomod to .zip. Some OSes will
+        warn you that this can make the file unstable; proceed anwyays. Once the file's extension is
+        changed, the .zip file can be opened as normal and extracted to the "addins" folder.
 
-    Most file extraction software will do this properly, but if you want to check, make sure that the 
-    addin's "addin.xml" is two folders down. For example, if your addin is named "addin_name", make sure 
-    that "Globin/addins/addin_name/addin.xml" is a valid filepath. If the addin data (including "addin.xml") 
-    is a layer too shallow or a layer too deep, Globin will not be able to install it properly.
+        Most file extraction software will do this properly, but if you want to check, make sure that the 
+        addin's "addin.xml" is two folders down. For example, if your addin is named "addin_name", make sure 
+        that "Globin/addins/addin_name/addin.xml" is a valid filepath. If the addin data (including "addin.xml") 
+        is a layer too shallow or a layer too deep, Globin will not be able to install it properly.
 
     ## 2.3: Incompatible Addins
 

--- a/README.txt
+++ b/README.txt
@@ -137,25 +137,40 @@ for a beginner's guide, which will explain far better than this section will be 
     ## 2.2: Adding Addins
 
     As mentioned in section 1, Globin operates using the organization system of .goomod files. However,
-    Globin is unable to read these files while they are compressed. To make them readable, they need to
-    be extracted to the "addins" folder. Most file extraction software will do this properly, but if
-    you want to check, make sure that the addin's "addin.xml" is two folders down. For example, if your
-    addin is named "addin_name", make sure that "Globin/addins/addin_name/addin.xml" is a valid filepath.
-    If the addin data (including "addin.xml") is a layer too shallow or a layer too deep, Globin will not
-    be able to install it properly.
+    Globin is unable to read these files while they are compressed. To make them readable to Globin, 
+    they need to be extracted to the "addins" folder. There are two ways to do it: automatic and manual.
 
     As a brief footnote, not all addins you install will be compatible with each other, and sometimes
     you may wish to remove some addins. In cases where you wish to table an incompatible addin or one
     you just don't want anymore, you can move that addin to the "not-in-use" folder. This folder is not
     read by Globin, it is simply there for ease of moving addins to and from the "addins" folder.
+    
+    ## 2.2.1: Unpacking .goomod files automatically
+    
+    To automatically extract the contents of a .goomod file into the Globin folder, run the Globin 
+    with "add" command line option. For example, to extract "C:\Users\Me\Documents\addin.goomod",
+    execute the following command:
+    - python3 globin.py add "C:\Users\Me\Documents\addin.goomod" 
 
-    ## 2.3: How To Unzip A .goomod File
-
+    ## 2.2.2: Unpacking .goomod Files Manually
+    
     Extracting the contents of a .goomod file is required for Globin to read them. This is a fairly
     simple step, but caution must be taken to not skip it. To extract the contents of a .goomod file,
     first use the rename function to change the file's extension from .goomod to .zip. Some OSes will
     warn you that this can make the file unstable; proceed anwyays. Once the file's extension is
     changed, the .zip file can be opened as normal and extracted to the "addins" folder.
+
+    Most file extraction software will do this properly, but if you want to check, make sure that the 
+    addin's "addin.xml" is two folders down. For example, if your addin is named "addin_name", make sure 
+    that "Globin/addins/addin_name/addin.xml" is a valid filepath. If the addin data (including "addin.xml") 
+    is a layer too shallow or a layer too deep, Globin will not be able to install it properly.
+
+    ## 2.3: Incompatible Addins
+
+    Not all addins you install will be compatible with each other, and sometimes you may wish to remove 
+    some addins. In cases where you wish to table an incompatible addin or one you just don't want anymore, 
+    you can move that addin to the "not-in-use" folder. This folder is not read by Globin, it is simply
+    there for ease of moving addins to and from the "addins" folder.
 
     ## 2.4: Dependencies
 
@@ -191,6 +206,7 @@ for a beginner's guide, which will explain far better than this section will be 
     an error, refer to section 5.
 
     Globin supports several command-line arguments:
+    - "python3 globin.py add <filename>" adds a new addin to the "addins" folder;
     - "python3 globin.py run" is the default behavior, described above; 
     - "python3 globin.py build" installs all addins without launching World Of Goo;
     - "python3 globin.py help" displays the info message.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@ Latest version: v0.9.1
 
 Version history:
 
+v0.9.3
+- Added a new command: add
+
 v0.9.2
 - Added command line arguments to Globin.
 

--- a/globin.py
+++ b/globin.py
@@ -6,10 +6,11 @@ import platform
 import shutil
 import sys
 import subprocess
+import zipfile
 
 def main() :
     user_action         = ""
-    user_action_choices = ["build", "run", "help"]
+    user_action_choices = ["build", "run", "add", "help"]
 
     if len(sys.argv) <= 1:
         user_action = "run"
@@ -28,6 +29,12 @@ def main() :
         if build_addins(wog_dir) and user_action == "run":
             launch_world_of_goo(wog_dir)
 
+    if user_action == "add":
+        if len(sys.argv) <= 2 or not os.path.isfile(sys.argv[2]) or not sys.argv[2].endswith(".goomod"):
+            print("Please provide a valid addin file!")
+        else:
+            add_addin(sys.argv[2])
+
     if user_action == "help":
         display_help()
 
@@ -36,9 +43,22 @@ def display_help():
     print("A tool for installing mods for World of Goo 1.5\n")
 
     print("Usage:")
-    print("python globin.py build: Installs the addins to the World Of Goo directory")
-    print("python globin.py run:   Installs the addins and launches World Of Goo")
-    print("python globin.py help:  Displays this message")
+    print("python globin.py build:          Installs the addins to the World Of Goo directory")
+    print("python globin.py run:            Installs the addins and launches World Of Goo")
+    print("python globin.py add <filename>: Adds the addin to the list of installed addins")
+    print("python globin.py help:           Displays this message")
+
+def add_addin(filename):
+    addins_dir = os.path.join(os.getcwd(), "addins")
+    if not os.path.isdir(addins_dir):
+        os.mkdir(addins_dir)
+
+    addin_name = os.path.splitext(os.path.basename(filename))[0]
+    addin_dir = os.path.join(addins_dir, addin_name)
+    os.mkdir(addin_dir)
+
+    with zipfile.ZipFile(filename, 'r') as addin_archive:
+        addin_archive.extractall(addin_dir)
 
 def build_addins(wog_dir):
     print("Starting...")


### PR DESCRIPTION
I find it tedious to manually rename and unpack .goomod files. I think a command-line option would be a good idea.