### PR TITLE
Added "list" command to display the list of installed addins

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -198,7 +198,7 @@ for a beginner's guide, which will explain far better than this section will be 
 
     The easiest way to run Globin is to use your computer's built-in command line terminal. To run
     Globin from the command line, navigate to the Globin directory and enter the command
-    "python3 globin.py". This will automatically run Globin, installing all addins in the "addins"
+    "python3 globin.py run". This will automatically run Globin, installing all addins in the "addins"
     folder and placing a button in Chapter 1 for each installed level (except levels in full
     chapters). After that, Globin automatically launches World of Goo. If running Globin gives 
     an error, refer to section 5.
@@ -206,9 +206,9 @@ for a beginner's guide, which will explain far better than this section will be 
     Globin supports several command-line arguments:
     - "python3 globin.py list <names|paths|all>" displays the list of installed addins;
     - "python3 globin.py add <filename>" adds a new addin to the "addins" folder;
-    - "python3 globin.py run" is the default behavior, described above; 
+    - "python3 globin.py run" installs all addins and launches World of Goo; 
     - "python3 globin.py build" installs all addins without launching World Of Goo;
-    - "python3 globin.py help" displays the info message.
+    - "python3 globin.py help" displays the info message. This is also the default behavior.
 
     Repeatedly using Globin will cause files with text appended to them (generally files in one or
     more "merge" folders) to build up with lots of text referencing the same object or objects.

--- a/README.txt
+++ b/README.txt
@@ -204,6 +204,7 @@ for a beginner's guide, which will explain far better than this section will be 
     an error, refer to section 5.
 
     Globin supports several command-line arguments:
+    - "python3 globin.py list <names|paths|all>" displays the list of installed addins;
     - "python3 globin.py add <filename>" adds a new addin to the "addins" folder;
     - "python3 globin.py run" is the default behavior, described above; 
     - "python3 globin.py build" installs all addins without launching World Of Goo;

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version history:
 
 v0.9.4
 - Added a new command: list
+- Changed default behavior from "run" to "help"
 
 v0.9.3
 - Added a new command: add

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
-Latest version: v0.9.1
+Latest version: v0.9.4
 
 Version history:
+
+v0.9.4
+- Added a new command: list
 
 v0.9.3
 - Added a new command: add

--- a/globin.py
+++ b/globin.py
@@ -13,7 +13,7 @@ def main() :
     user_action_choices = ["build", "run", "add", "list", "help"]
 
     if len(sys.argv) <= 1:
-        user_action = "run"
+        user_action = "help"
     else:
         user_action = sys.argv[1]
 

--- a/globin.py
+++ b/globin.py
@@ -10,7 +10,7 @@ import zipfile
 
 def main() :
     user_action         = ""
-    user_action_choices = ["build", "run", "add", "help"]
+    user_action_choices = ["build", "run", "add", "list", "help"]
 
     if len(sys.argv) <= 1:
         user_action = "run"
@@ -35,6 +35,9 @@ def main() :
         else:
             add_addin(sys.argv[2])
 
+    if user_action == "list":
+        display_addin_list()
+
     if user_action == "help":
         display_help()
 
@@ -45,8 +48,62 @@ def display_help():
     print("Usage:")
     print("python globin.py build:          Installs the addins to the World Of Goo directory")
     print("python globin.py run:            Installs the addins and launches World Of Goo")
+    print("python globin.py list:           Displays the list of installed addins")
     print("python globin.py add <filename>: Adds the addin to the list of installed addins")
     print("python globin.py help:           Displays this message")
+
+def display_addin_list():
+    addins_dir     = os.path.join(os.getcwd(), "addins")
+    not_in_use_dir = os.path.join(os.getcwd(), "not-in-use") 
+    
+    addin_names            = gather_addin_names(addins_dir)
+    not_in_use_addin_names = gather_addin_names(not_in_use_dir)
+
+    if len(addin_names) == 0 and len(not_in_use_addin_names) == 0:
+        print("There are no addins installed.")
+    else:
+        if len(addin_names) > 0:
+            print("Installed addins:")
+
+            for addin_name in addin_names:
+                print("- " + addin_name)
+
+            print("")
+
+        if len(not_in_use_addin_names) > 0:
+            print("Addins not in use:")
+
+            for addin_name in not_in_use_addin_names:
+                print("- " + addin_name)
+
+            print("")
+
+def gather_addin_names(addins_dir):
+    addin_names = []
+
+    if os.path.isdir(addins_dir):
+        addins_dir_contents = os.listdir(addins_dir)
+
+        for addin_folder in addins_dir_contents:
+            addin_name = ""
+
+            addin_xml_path = os.path.join(addins_dir, addin_folder + "/addin.xml")
+            if os.path.isfile(addin_xml_path):
+                addin_info = open(addin_xml_path, "r", errors="ignore")
+                addin_parser = BeautifulSoup(addin_info, "xml")
+            
+                addin_name_record = addin_parser.find("name")
+                if addin_name_record is not None:
+                    addin_name = addin_name_record.contents[0]
+
+                addin_info.close()
+
+            if addin_name == "": #Fallback to id if couldn't read name
+                addin_name = addin_folder
+
+            addin_names.append(addin_name)
+
+    return addin_names
 
 def add_addin(filename):
     addins_dir = os.path.join(os.getcwd(), "addins")

--- a/globin.py
+++ b/globin.py
@@ -36,7 +36,12 @@ def main() :
             add_addin(sys.argv[2])
 
     if user_action == "list":
-        display_addin_list()
+        addin_list_selected_option = "names"
+        addin_list_option_choices = ["paths", "names", "all"]
+        if len(sys.argv) >= 3 and sys.argv[2] in addin_list_option_choices:
+            addin_list_selected_option = sys.argv[2]
+
+        display_addin_list(addin_list_selected_option)
 
     if user_action == "help":
         display_help()
@@ -46,13 +51,13 @@ def display_help():
     print("A tool for installing mods for World of Goo 1.5\n")
 
     print("Usage:")
-    print("python globin.py build:          Installs the addins to the World Of Goo directory")
-    print("python globin.py run:            Installs the addins and launches World Of Goo")
-    print("python globin.py list:           Displays the list of installed addins")
-    print("python globin.py add <filename>: Adds the addin to the list of installed addins")
-    print("python globin.py help:           Displays this message")
+    print("python globin.py build:                   Installs the addins to the World Of Goo directory")
+    print("python globin.py run:                     Installs the addins and launches World Of Goo")
+    print("python globin.py list <names|paths|all>:  Displays the list of installed addins")
+    print("python globin.py add <filename>:          Adds the addin to the list of installed addins")
+    print("python globin.py help:                    Displays this message")
 
-def display_addin_list():
+def display_addin_list(addin_list_selected_option):
     addins_dir     = os.path.join(os.getcwd(), "addins")
     not_in_use_dir = os.path.join(os.getcwd(), "not-in-use") 
     
@@ -65,16 +70,26 @@ def display_addin_list():
         if len(addin_names) > 0:
             print("Installed addins:")
 
-            for addin_name in addin_names:
-                print("- " + addin_name)
+            for addin_folder, addin_name in addin_names:
+                if addin_list_selected_option == "paths":
+                    print("- " + addin_folder)
+                elif addin_list_selected_option == "names":
+                    print("- " + addin_name)
+                elif addin_list_selected_option == "all":
+                    print("- [" + addin_folder + "] " + addin_name)
 
             print("")
 
         if len(not_in_use_addin_names) > 0:
             print("Addins not in use:")
 
-            for addin_name in not_in_use_addin_names:
-                print("- " + addin_name)
+            for addin_folder, addin_name in not_in_use_addin_names:
+                if addin_list_selected_option == "paths":
+                    print("- " + addin_folder)
+                elif addin_list_selected_option == "names":
+                    print("- " + addin_name)
+                elif addin_list_selected_option == "all":
+                    print("- [" + addin_folder + "] " + addin_name)
 
             print("")
 
@@ -98,10 +113,7 @@ def gather_addin_names(addins_dir):
 
                 addin_info.close()
 
-            if addin_name == "": #Fallback to id if couldn't read name
-                addin_name = addin_folder
-
-            addin_names.append(addin_name)
+            addin_names.append((addin_folder, addin_name))
 
     return addin_names
 


### PR DESCRIPTION
One of the requests from TODO.txt is a command to disable the addins: i.e. move them between "addins" and "not-in-use" folders. It would be cumbersome to use without knowing which addins are installed in the first place. I propose adding a "list" command, which displays the list of currently installed addins.

The command displays both in-use and not-in-use addins (in separate lists). The command supports three options: 
- "names" displays addin names only (default option);
- "paths" displays addin folder names (will be handy for disabling and removing addins);
- "all" displays both.  