### PR TITLE
Added enable and disable command line arguments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -17,7 +17,6 @@
 ### Table of Contents
 - 1: What You Need To Know First
   -- 1.1: Current Constraints of Globin
-  -- 1.2: Extra Notes for GitHub
 - 2: Setting Up Globin
   -- 2.1: Setting Your World of Goo Directory
      --- 2.1.1: (Optional) Setting Your Steam Directory
@@ -94,11 +93,6 @@ modifying these folders' contents.
     that custom cutscenes will be skipped, and overriden cutscenes will crash the game. This is
     prevented by preserving the resources file of each vanilla cutscene. These cutscenes can still
     be modified by directly modifying the resources directly, however.
-    
-    ## 1.2: Extra Notes for GitHub
-    
-    GitHub does not support adding empty directories. This means the "addins" and "not-in-use" folder
-    have to be added manually. This may also apply to a few other folders in the repository.
 
 ~~~
 

--- a/README.txt
+++ b/README.txt
@@ -170,6 +170,20 @@ for a beginner's guide, which will explain far better than this section will be 
     you can move that addin to the "not-in-use" folder. This folder is not read by Globin, it is simply
     there for ease of moving addins to and from the "addins" folder.
 
+    You can use "enable" and "disable" command line arguments to move the addin between "addins" and 
+    "not-in-use" folders.
+
+    For example, suppose the addin is stored in "globin/addins/my.addin" folder. To mark it as not-in-use, 
+    execute the following command:
+    - python3 globin.py disable my.addin
+
+    Likewise, suppose the not-in-use addin is stored in "globin/not-in-use/my.addin" folder. To mark it
+    as in-use, execute the following command:
+    - python3 globin.py enable my.addin
+
+    To check the folder names of the addins, execute "list all" command:
+    - python3 globin.py list all
+
     ## 2.4: Dependencies
 
     Globin is a program that runs on Python3. As such, your system needs Python3 installed to run Globin.
@@ -206,9 +220,14 @@ for a beginner's guide, which will explain far better than this section will be 
     Globin supports several command-line arguments:
     - "python3 globin.py list <names|paths|all>" displays the list of installed addins;
     - "python3 globin.py add <filename>" adds a new addin to the "addins" folder;
+    - "python3 globin.py enable <addin folder>" marks the addin as in-use;
+    - "python3 globin.py disable <addin folder>" marks the addin as not-in-use;
     - "python3 globin.py run" installs all addins and launches World of Goo; 
     - "python3 globin.py build" installs all addins without launching World Of Goo;
     - "python3 globin.py help" displays the info message. This is also the default behavior.
+
+    The options "enable" and "disable" require typing the name of the folder which stores the addin.
+    You can check folder names with "list paths" or "list all" options.
 
     Repeatedly using Globin will cause files with text appended to them (generally files in one or
     more "merge" folders) to build up with lots of text referencing the same object or objects.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@ Latest version: v0.9.4
 
 Version history:
 
+v0.9.5
+- Added new commands: enable and disable
+
 v0.9.4
 - Added a new command: list
 - Changed default behavior from "run" to "help"

--- a/globin.py
+++ b/globin.py
@@ -7,10 +7,11 @@ import shutil
 import sys
 import subprocess
 import zipfile
+import shutil
 
 def main() :
     user_action         = ""
-    user_action_choices = ["build", "run", "add", "list", "help"]
+    user_action_choices = ["build", "run", "add", "enable", "disable", "list", "help"]
 
     if len(sys.argv) <= 1:
         user_action = "help"
@@ -35,6 +36,16 @@ def main() :
         else:
             add_addin(sys.argv[2])
 
+    if user_action == "enable" or user_action == "disable":
+        if len(sys.argv) <= 2:
+            print("Please provide the folder name of an installed addin!")
+
+        elif user_action == "enable":
+            move_addin(sys.argv[2], "not-in-use", "addins")
+
+        elif user_action == "disable":
+            move_addin(sys.argv[2], "addins", "not-in-use")
+
     if user_action == "list":
         addin_list_selected_option = "names"
         addin_list_option_choices = ["paths", "names", "all"]
@@ -55,6 +66,8 @@ def display_help():
     print("python globin.py run:                     Installs the addins and launches World Of Goo")
     print("python globin.py list <names|paths|all>:  Displays the list of installed addins")
     print("python globin.py add <filename>:          Adds the addin to the list of installed addins")
+    print("python globin.py enable <addin folder>:   Marks the addin as in-use")
+    print("python globin.py disable <addin folder>:  Marks the addin as not-in-use")
     print("python globin.py help:                    Displays this message")
 
 def display_addin_list(addin_list_selected_option):
@@ -128,6 +141,25 @@ def add_addin(filename):
 
     with zipfile.ZipFile(filename, 'r') as addin_archive:
         addin_archive.extractall(addin_dir)
+
+def move_addin(addin_name, dir_from, dir_to):
+    path_from = os.path.join(os.getcwd(), dir_from)
+    path_from = os.path.join(path_from, addin_name)
+
+    path_to = os.path.join(os.getcwd(), dir_to)
+    if not(os.path.isdir(path_to)):
+        os.mkdir(path_to)
+        
+    path_to = os.path.join(dir_to, addin_name)
+
+    if os.path.exists(path_to):
+        return #Enabling an enabled addin or disabling a disabled addin is not considered an error
+    
+    if not os.path.exists(path_from):
+        print("Please provide the folder name of an installed addin!")
+        return
+
+    shutil.move(path_from, path_to)
 
 def build_addins(wog_dir):
     print("Starting...")


### PR DESCRIPTION
These ones are intended for moving addins to "not-in-use" folder and back.

These commands accept the names of the addin folders. I decided to go this route for two reasons:
- Proper addin names from addin.xml can be mouthful, they are longer to type and it's easier to make a mistake;
- Addin names from addin.xml don't have to be unique, unlike folder names.

Note: there is a section in README.txt, "Extra Notes for GitHub", about having to create "addins" and "not-in-use" folders. Now this section is only relevant if the user manipulates addins manually; the commands "enable", "disable" and "add" automatically create the necessary folders. I haven't touched this section, though I'm not sure it's needed anymore.